### PR TITLE
Builder should use ready. Form to mimic react more.

### DIFF
--- a/src/components/Form.ts
+++ b/src/components/Form.ts
@@ -89,6 +89,7 @@ export class Form extends Vue {
             .then(
               (formio: any): any => {
                 this.formio = formio;
+                this.formio.src = this.src
                 return formio;
               },
             )
@@ -105,6 +106,12 @@ export class Form extends Vue {
             .then(
               (formio: any): any => {
                 this.formio = formio;
+                this.formio.form = this.form
+
+                if (this.url) {
+                  this.formio.url = this.url;
+                }
+
                 return formio;
               },
             )


### PR DESCRIPTION
Builder not using `ready` causes (atleast for me) form change not to trigger, when form is changed outside of the basic builder.

Also, react version wants to set default values for `form` and `options`, which would render `this.form !== undefined`.

Not sure how necessary builder existence check truely is, but since it was added for React, I added it for vue as well.

There were some additional changes done in form for React. I wonder are these things useful.