### PR TITLE
set esModuleInterop to true in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "noImplicitAny": false,
     "strictNullChecks": false,
     "target": "es5",


### PR DESCRIPTION
This resolves the bug seen in issue #29. I'm trying to use vue-formio in a project that is not using typescript and that error was coming up. With this change to tsconfig, I'm able to use vue-formio.